### PR TITLE
Added higher blast version for prokka to binset.yaml

### DIFF
--- a/workflow/envs/binset.yaml
+++ b/workflow/envs/binset.yaml
@@ -8,3 +8,4 @@ dependencies:
   - tqdm
   - biopython
   - prokka
+  - blast=2.2.31


### PR DESCRIPTION
Prokka demands a higher blastp version of 2.2 or higher, created conda environment provided version 2.11.0. Added blast=2.2.31 to binset.yaml Prokka runs now smoothly.   